### PR TITLE
Add Fallback to Treasury

### DIFF
--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -58,6 +58,12 @@ contract Treasury is ReentrancyGuard, Ownable {
         bondDepletionFloor = 1000e18;
         lastAllocated = now;
     }
+    
+    /* ========== FALLBACK ========== */
+    
+    function() external payable {
+        revert();
+    }
 
     // ========== EXTERNAL SETTERS ==========
 


### PR DESCRIPTION
As balance of the Treasury contract is updated with `uint256 treasuryBalance = IERC20(cash).balanceOf(address(this));` , a front-running attack may be possible by sending Basis Cash to the contract without any data. This PR resolves this issue by adding a Solidity fallback function & immediately reverting all invalid calls handled through fallback.