### PR TITLE
Fix epoch mechanism

### DIFF
--- a/contracts/test/EpochTester.sol
+++ b/contracts/test/EpochTester.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.6.0;
+
+import '../utils/Epoch.sol';
+
+contract EpochTester is Epoch {
+    constructor(
+        uint256 _period,
+        uint256 _startTime,
+        uint256 _startEpoch
+    ) public Epoch(_period, _startTime, _startEpoch) {}
+
+    function testCheckStartTime() public checkStartTime {}
+
+    function testCheckEpoch() public checkEpoch {}
+}

--- a/contracts/utils/Epoch.sol
+++ b/contracts/utils/Epoch.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.6.0;
 
+import '@openzeppelin/contracts/math/Math.sol';
 import '@openzeppelin/contracts/math/SafeMath.sol';
 
 import '../owner/Operator.sol';
@@ -9,7 +10,7 @@ contract Epoch is Operator {
 
     uint256 private period;
     uint256 private startTime;
-    uint256 private epoch;
+    uint256 private lastExecutedAt;
 
     /* ========== CONSTRUCTOR ========== */
 
@@ -18,9 +19,10 @@ contract Epoch is Operator {
         uint256 _startTime,
         uint256 _startEpoch
     ) public {
+        require(_startTime > block.timestamp, 'Epoch: invalid start time');
         period = _period;
         startTime = _startTime;
-        epoch = _startEpoch;
+        lastExecutedAt = startTime.add(_startEpoch.mul(period));
     }
 
     /* ========== Modifier ========== */
@@ -32,29 +34,43 @@ contract Epoch is Operator {
     }
 
     modifier checkEpoch {
-        require(now >= nextEpochPoint(), 'Epoch: not allowed');
+        require(now > startTime, 'Epoch: not started yet');
+        require(getCurrentEpoch() >= getNextEpoch(), 'Epoch: not allowed');
 
         _;
 
-        epoch = epoch.add(1);
+        lastExecutedAt = block.timestamp;
     }
 
     /* ========== VIEW FUNCTIONS ========== */
 
-    function getCurrentEpoch() public view returns (uint256) {
-        return epoch;
+    // epoch
+    function getLastEpoch() public view returns (uint256) {
+        return lastExecutedAt.sub(startTime).div(period);
     }
 
+    function getCurrentEpoch() public view returns (uint256) {
+        return Math.max(startTime, block.timestamp).sub(startTime).div(period);
+    }
+
+    function getNextEpoch() public view returns (uint256) {
+        if (startTime == lastExecutedAt) {
+            return getLastEpoch();
+        }
+        return getLastEpoch().add(1);
+    }
+
+    function nextEpochPoint() public view returns (uint256) {
+        return startTime.add(getNextEpoch().mul(period));
+    }
+
+    // params
     function getPeriod() public view returns (uint256) {
         return period;
     }
 
     function getStartTime() public view returns (uint256) {
         return startTime;
-    }
-
-    function nextEpochPoint() public view returns (uint256) {
-        return startTime.add(epoch.mul(period));
     }
 
     /* ========== GOVERNANCE ========== */

--- a/test/Boardroom.test.ts
+++ b/test/Boardroom.test.ts
@@ -56,9 +56,9 @@ describe('Boardroom', () => {
       await expect(boardroom.connect(whale).stake(STAKE_AMOUNT))
         .to.emit(boardroom, 'Staked')
         .withArgs(whale.address, STAKE_AMOUNT);
-        
+
       const latestSnapshotIndex = await boardroom.latestSnapshotIndex();
-        
+
       expect(await boardroom.balanceOf(whale.address)).to.eq(STAKE_AMOUNT);
 
       expect(await boardroom.getLastSnapshotIndexOf(whale.address)).to.eq(
@@ -152,9 +152,7 @@ describe('Boardroom', () => {
         .to.emit(boardroom, 'RewardAdded')
         .withArgs(operator.address, SEIGNIORAGE_AMOUNT);
 
-      expect(await boardroom.earned(whale.address)).to.eq(
-        SEIGNIORAGE_AMOUNT
-      );
+      expect(await boardroom.earned(whale.address)).to.eq(SEIGNIORAGE_AMOUNT);
     });
 
     it('should fail when user tries to allocate with zero amount', async () => {
@@ -176,8 +174,8 @@ describe('Boardroom', () => {
         share.connect(operator).mint(whale.address, STAKE_AMOUNT),
         share.connect(whale).approve(boardroom.address, STAKE_AMOUNT),
 
-        share.connect(operator).mint(abuser.address, STAKE_AMOUNT),                    
-        share.connect(abuser).approve(boardroom.address, STAKE_AMOUNT), 
+        share.connect(operator).mint(abuser.address, STAKE_AMOUNT),
+        share.connect(abuser).approve(boardroom.address, STAKE_AMOUNT),
       ]);
       await boardroom.connect(whale).stake(STAKE_AMOUNT);
     });
@@ -195,22 +193,19 @@ describe('Boardroom', () => {
       expect(await boardroom.balanceOf(whale.address)).to.eq(STAKE_AMOUNT);
     });
 
-   it('should claim devidends correctly even after other person stakes after snapshot', async () => {
+    it('should claim devidends correctly even after other person stakes after snapshot', async () => {
       await cash.connect(operator).mint(operator.address, SEIGNIORAGE_AMOUNT);
       await cash
         .connect(operator)
         .approve(boardroom.address, SEIGNIORAGE_AMOUNT);
       await boardroom.connect(operator).allocateSeigniorage(SEIGNIORAGE_AMOUNT);
 
-      await boardroom.connect(abuser).stake(STAKE_AMOUNT);        
+      await boardroom.connect(abuser).stake(STAKE_AMOUNT);
 
       await expect(boardroom.connect(whale).claimReward())
         .to.emit(boardroom, 'RewardPaid')
         .withArgs(whale.address, SEIGNIORAGE_AMOUNT);
       expect(await boardroom.balanceOf(whale.address)).to.eq(STAKE_AMOUNT);
-    });      
-      
+    });
   });
-
-    
 });

--- a/test/Oracle.test.ts
+++ b/test/Oracle.test.ts
@@ -8,14 +8,9 @@ import UniswapV2Router from '@uniswap/v2-periphery/build/UniswapV2Router02.json'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 import { Provider } from '@ethersproject/providers';
 
-import { advanceTimeAndBlock } from './shared/utilities';
+import { advanceTimeAndBlock, latestBlocktime } from './shared/utilities';
 
 chai.use(solidity);
-
-async function latestBlocktime(provider: Provider): Promise<number> {
-  const { timestamp } = await provider.getBlock('latest');
-  return timestamp;
-}
 
 async function addLiquidity(
   provider: Provider,
@@ -122,7 +117,7 @@ describe('Oracle', () => {
       );
 
       // epoch 0
-      await expect(oracle.update()).to.revertedWith('Epoch: not allowed');
+      await expect(oracle.update()).to.revertedWith('Epoch: not started yet');
       expect(await oracle.nextEpochPoint()).to.eq(oracleStartTime);
       expect(await oracle.getCurrentEpoch()).to.eq(BigNumber.from(0));
 
@@ -132,7 +127,7 @@ describe('Oracle', () => {
       await expect(oracle.update()).to.emit(oracle, 'Updated');
 
       expect(await oracle.nextEpochPoint()).to.eq(oracleStartTime.add(DAY));
-      expect(await oracle.getCurrentEpoch()).to.eq(BigNumber.from(1));
+      expect(await oracle.getCurrentEpoch()).to.eq(BigNumber.from(0));
       // check double update
       await expect(oracle.update()).to.revertedWith('Epoch: not allowed');
     });

--- a/test/Timelock.test.ts
+++ b/test/Timelock.test.ts
@@ -4,7 +4,7 @@ import { solidity } from 'ethereum-waffle';
 import { Contract, ContractFactory, BigNumber, utils } from 'ethers';
 import { Provider } from '@ethersproject/providers';
 
-import { advanceTimeAndBlock } from './shared/utilities';
+import { advanceTimeAndBlock, latestBlocktime } from './shared/utilities';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 import { ParamType } from 'ethers/lib/utils';
 
@@ -13,11 +13,6 @@ chai.use(solidity);
 const DAY = 86400;
 const ETH = utils.parseEther('1');
 const ZERO_ADDR = '0x0000000000000000000000000000000000000000';
-
-async function latestBlocktime(provider: Provider): Promise<number> {
-  const { timestamp } = await provider.getBlock('latest');
-  return timestamp;
-}
 
 function encodeParameters(
   types: Array<string | ParamType>,

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -1,4 +1,19 @@
-import { Block, JsonRpcProvider } from '@ethersproject/providers';
+import { Block, JsonRpcProvider, Provider } from '@ethersproject/providers';
+import { ethers } from 'hardhat';
+import { ParamType } from 'ethers/lib/utils';
+
+export function encodeParameters(
+  types: Array<string | ParamType>,
+  values: Array<any>
+) {
+  const abi = new ethers.utils.AbiCoder();
+  return abi.encode(types, values);
+}
+
+export async function latestBlocktime(provider: Provider): Promise<number> {
+  const { timestamp } = await provider.getBlock('latest');
+  return timestamp;
+}
 
 export async function advanceTime(
   provider: JsonRpcProvider,

--- a/test/utils/Epoch.test.ts
+++ b/test/utils/Epoch.test.ts
@@ -1,0 +1,103 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { solidity } from 'ethereum-waffle';
+import { Contract, ContractFactory, BigNumber, utils } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+import { advanceTimeAndBlock, latestBlocktime } from '../shared/utilities';
+
+chai.use(solidity);
+
+describe('Epoch', () => {
+  const DAY = 86400;
+  const ETH = utils.parseEther('1');
+  const ZERO = BigNumber.from(0);
+
+  const { provider } = ethers;
+
+  let operator: SignerWithAddress;
+
+  before('provider & accounts setting', async () => {
+    [operator] = await ethers.getSigners();
+  });
+
+  let Epoch: ContractFactory;
+
+  before('fetch contract factories', async () => {
+    Epoch = await ethers.getContractFactory('EpochTester');
+  });
+
+  let epoch: Contract;
+
+  beforeEach('deploy contracts', async () => {
+    epoch = await Epoch.connect(operator).deploy(
+      DAY,
+      (await latestBlocktime(provider)) + DAY,
+      0
+    );
+  });
+
+  it('#getLastEpoch', async () => {
+    expect(await epoch.getLastEpoch()).to.eq(0);
+    await advanceTimeAndBlock(provider, DAY);
+    await epoch.testCheckEpoch();
+    expect(await epoch.getLastEpoch()).to.eq(0);
+    await advanceTimeAndBlock(provider, DAY);
+    await epoch.testCheckEpoch();
+    expect(await epoch.getLastEpoch()).to.eq(1);
+    await advanceTimeAndBlock(provider, DAY);
+    await epoch.testCheckEpoch();
+    expect(await epoch.getLastEpoch()).to.eq(2);
+    await advanceTimeAndBlock(provider, DAY);
+    await advanceTimeAndBlock(provider, DAY);
+    await epoch.testCheckEpoch();
+    expect(await epoch.getLastEpoch()).to.eq(4);
+  });
+
+  it('#getCurrentEpoch', async () => {
+    expect(await epoch.getCurrentEpoch()).to.eq(0);
+    await advanceTimeAndBlock(provider, DAY);
+    expect(await epoch.getCurrentEpoch()).to.eq(0);
+    await advanceTimeAndBlock(provider, DAY);
+    expect(await epoch.getCurrentEpoch()).to.eq(1);
+    await advanceTimeAndBlock(provider, DAY);
+    expect(await epoch.getCurrentEpoch()).to.eq(2);
+    await advanceTimeAndBlock(provider, DAY);
+    await advanceTimeAndBlock(provider, DAY);
+    expect(await epoch.getCurrentEpoch()).to.eq(4);
+  });
+
+  it('#getNextEpoch', async () => {
+    expect(await epoch.getNextEpoch()).to.eq(0);
+    await advanceTimeAndBlock(provider, DAY);
+    await epoch.testCheckEpoch();
+    expect(await epoch.getNextEpoch()).to.eq(1);
+    await advanceTimeAndBlock(provider, DAY);
+    await epoch.testCheckEpoch();
+    expect(await epoch.getNextEpoch()).to.eq(2);
+    await advanceTimeAndBlock(provider, DAY);
+    await epoch.testCheckEpoch();
+    expect(await epoch.getNextEpoch()).to.eq(3);
+    await advanceTimeAndBlock(provider, DAY);
+    await advanceTimeAndBlock(provider, DAY);
+    await epoch.testCheckEpoch();
+    expect(await epoch.getNextEpoch()).to.eq(5);
+  });
+
+  describe('before startTime', () => {
+    it('check status', async () => {
+      expect(await epoch.getLastEpoch()).to.eq(0);
+      expect(await epoch.getCurrentEpoch()).to.eq(0);
+      expect(await epoch.getNextEpoch()).to.eq(0);
+      expect(await epoch.nextEpochPoint()).to.eq(await epoch.getStartTime());
+    });
+
+    it('should fail', async () => {
+      await expect(epoch.testCheckStartTime()).to.revertedWith(
+        'Epoch: not started yet'
+      );
+      await expect(epoch.testCheckEpoch()).to.revertedWith(
+        'Epoch: not started yet'
+      );
+    });
+  });
+});


### PR DESCRIPTION
This pull request resolves an issue where updated `period` values set through `setPeriod()` are not properly reflected with epoch calculation logic.

Previously epoch calculation was done linearly regardless of `period` (i.e. incrementing by 1). This PR includes the following changes:
* `currentEpoch` is calculated with `div(currentTime - startTime, period)`
* `last executed epoch (lastEpoch)` is calculated with `div(lastExecutedAt - startTime, period)`
* if `currentEpoch >= lastEpoch +1`, epoch operations are executed; transaction is reverted if otherwise.