### PR TITLE
Basis Cash Improvement Proposal #10 - Change Calculation of Bond Conversion Limits to 24hours Epochs instead of 1 hour

### DIFF
--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -210,14 +210,11 @@ contract Treasury is ContractGuard, Epoch {
     /* ========== MUTABLE FUNCTIONS ========== */
 
     function _updateConversionLimit(uint256 cashPrice) internal {
-        uint256 currentEpoch = Epoch(bondOracle).getLastEpoch(); // lastest update time
-        if (lastBondOracleEpoch != currentEpoch) {
-            uint256 percentage = cashPriceOne.sub(cashPrice);
-            cashConversionLimit = circulatingSupply().mul(percentage).div(1e18);
-            accumulatedCashConversion = 0;
+        uint256 percentage = cashPriceOne.sub(cashPrice);
+        cashConversionLimit = circulatingSupply().mul(percentage).div(1e18);
+        accumulatedCashConversion = 0;
 
-            lastBondOracleEpoch = currentEpoch;
-        }
+        lastBondOracleEpoch = currentEpoch;
     }
 
     function _updateCashPrice() internal {
@@ -245,7 +242,6 @@ contract Treasury is ContractGuard, Epoch {
             cashPrice < cashPriceOne, // price < $1
             'Treasury: cashPrice not eligible for bond purchase'
         );
-        _updateConversionLimit(cashPrice);
 
         // swap exact limit
         amount = Math.min(
@@ -306,6 +302,10 @@ contract Treasury is ContractGuard, Epoch {
     {
         _updateCashPrice();
         uint256 cashPrice = _getCashPrice(seigniorageOracle);
+
+        // update conversion limit to decide if we need to issue more bonds or not
+        _updateConversionLimit(cashPrice);
+
         if (cashPrice <= getCeilingPrice()) {
             return; // just advance epoch instead revert
         }


### PR DESCRIPTION
This is a suggestion that works on two points with regards to the [`_updateConversionLimit()`](https://github.com/Basis-Cash/basiscash-protocol/blob/5f74951cfe9c56476e9e6ccd9d7f5fb88db5979f/contracts/Treasury.sol#L212-L221) function which is used to decide how many bonds get issued on bond purchase.

**Motivation:**

As per the current implementation, say if the protocol is off by 5%, and say a supply of 10,000 BAC; then a debt cap of 500 BAB is made and now the protocol is allowed to issue debt by 5%.

However, this cap although reset every hour, can only be fulfilled after the 24-hour epoch and if the protocol is in its expansion phase. This means in our example it is theoretically possible to have 5% of the BAC circulation converted into debt (BAB), 24 times (every hour the cap resets)! 

**Solution**: Reset the debt cap once per 24hr epoch. Not every hour.

**For reference:** existing elastic stablecoin protocols such as ESD, issue debt only once per epoch.

Further, a second point that can possibly arise is when we look at the Epoch function. As per the code, it is possible to change the epoch duration from 24 hours to anything that the governance decides. However, epochs are not saved as integer counters but rather as timestamps (`Epoch.lastExecutedAt`), whereas the condition used in the `_updateConversionLimit()` is tracking epochs as integer counters. 

**Hypothetical scenario:** If currently the epoch is at 10 and we are counting 24 hours epochs. Say that the governance decides that we need to start counting 48-hour epochs instead; which means the protocol starts counting from epoch 5 henceforth. However, this would mean that `_updateConversionLimit()` will not execute for another 10 days because it looking for epoch 11 to continue.

**Solution**: In this PR I've made changes to improve the `_updateConversionLimit()` function by removing t he epoch conditions and calling it with the `allocateSeigniorage()` function. Have yet to write unit tests for this change.